### PR TITLE
firefox compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TabCloser",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Automatically close leftover tabs from services like Figma, Spotify, Zoom and other commonly redirected URLs.",
   "action": {
     "default_popup": "popup.html",
@@ -16,7 +16,8 @@
     "storage"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": [ "background.js" ]
   },
   "options_page": "options.html",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "TabCloser",
-  "version": "3.3.2",
+  "version": "3.3.1",
   "description": "Automatically close leftover tabs from services like Figma, Spotify, Zoom and other commonly redirected URLs.",
   "action": {
     "default_popup": "popup.html",
@@ -24,5 +24,11 @@
     "16": "images/icon16.png",
     "48": "images/icon48.png",
     "128": "images/icon128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "TabCloser@seth.social",
+      "strict_min_version": "144.0"
+    }
   }
 }


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support, firefox requires background.scripts instead of background.service_worker

Note: I was able to test notion on firefox with this update, but some more tests need to be done.
~~Note2: settings seems not to work, I'll look at it, but I do not know when I will be able to, feel free to propose updates.~~
Note3: second commit seems to fix settings, tested with zoom and notion on firefox