### PR TITLE
Close tabs after in-page redirect in Safari

### DIFF
--- a/background.js
+++ b/background.js
@@ -134,6 +134,15 @@ api.tabs.onCreated.addListener((tab) => {
   }
 });
 
+// Listen for URL reports from content scripts — covers in-page (History API) navigations
+// that tabs.onUpdated misses in Safari (e.g. Linear's redirect to ...?noRedirect=1)
+api.runtime.onMessage.addListener((message, sender) => {
+  if (message && message.type === 'tabcloser:url' && sender.tab && sender.tab.id != null) {
+    if (debug) console.log(`Content script reported URL (tab ${sender.tab.id}): ${message.url}`);
+    scheduleClose(sender.tab.id, message.url);
+  }
+});
+
 // Clean up tracking when tabs are closed by the user or other means
 api.tabs.onRemoved.addListener((tabId) => {
   if (pendingClose.has(tabId)) {

--- a/content-spa-nav.js
+++ b/content-spa-nav.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023-2026 Seth Cottle
+
+// This file is part of TabCloser.
+
+// TabCloser is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or any later version.
+
+// TabCloser is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Please see the
+// GNU General Public License for more details.
+
+// Safari single-page-app navigation shim.
+//
+// Some services (e.g. Linear) reach their final, closable URL via a client-side
+// route change rather than a full document load — for Linear, landing the tab on
+// `...?noRedirect=1` after the desktop-app handoff. In Safari, tabs.onUpdated does
+// not reliably fire for these in-page History API navigations, and Safari does not
+// support webNavigation.onHistoryStateUpdated. As a result the background script
+// never sees the final URL, so the predefined pattern never gets a chance to match
+// and the leftover tab is never closed.
+//
+// Content scripts run in an isolated world, so patching the page's
+// history.pushState/replaceState from here is unreliable (it only affects this
+// script's copy). Instead we observe location.href — which always reflects the page's
+// real URL — and report changes to the background script, which then runs its normal
+// scheduleClose() matching logic. This script only runs on the hosts TabCloser already
+// targets, so it does nothing on unrelated pages.
+
+(function () {
+  const api = typeof browser !== 'undefined' ? browser : chrome;
+
+  let lastReported = null;
+
+  function report() {
+    const url = location.href;
+    if (url === lastReported) return;
+    lastReported = url;
+    try {
+      api.runtime.sendMessage({ type: 'tabcloser:url', url });
+    } catch (error) {
+      // Background may be inactive; harmless — the next change will retry.
+    }
+  }
+
+  // Back/forward and hash changes fire on window in the isolated world.
+  window.addEventListener('popstate', report);
+  window.addEventListener('hashchange', report);
+
+  // Poll location.href to catch pushState/replaceState route changes the events miss.
+  setInterval(report, 500);
+
+  // Report the initial URL in case the redirect completed before injection.
+  report();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,26 @@
   "background": {
     "service_worker": "background.js"
   },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://app.asana.com/*",
+        "https://*.awsapps.com/*",
+        "https://discord.com/*",
+        "https://*.figma.com/*",
+        "https://linear.app/*",
+        "https://teams.microsoft.com/*",
+        "https://www.notion.so/*",
+        "https://*.slack.com/*",
+        "https://open.spotify.com/*",
+        "https://vscode.dev/*",
+        "https://*.webex.com/*",
+        "https://*.zoom.us/*"
+      ],
+      "js": ["content-spa-nav.js"],
+      "run_at": "document_start"
+    }
+  ],
   "options_page": "options.html",
   "icons": {
     "16": "images/icon16.png",


### PR DESCRIPTION
## What this fixes

In Safari, tabs that reach their final closable URL through an in-page navigation never get closed.

The clearest example is Linear. When you click a Linear link, it does its desktop-app handoff and the tab ends up on `...?noRedirect=1`. That final URL is reached via a client-side route change, not a full page load. The predefined Linear pattern already matches `...?noRedirect=1` correctly, so the regex isn't the problem. The problem is that the background script never sees that URL in Safari.

Two reasons for that:

- Safari doesn't reliably fire `tabs.onUpdated` for in-page History API navigations (`pushState`/`replaceState`).
- Safari doesn't support `webNavigation.onHistoryStateUpdated`, so the usual SPA workaround isn't available either.

So in Safari the only `onUpdated` event is the initial load, and by the time the URL settles on `...?noRedirect=1` nothing fires. The tab stays open.

## The change

A small content script (`content-spa-nav.js`) runs on the hosts TabCloser already targets. It watches `location.href` (poll + `popstate`/`hashchange`) and reports URL changes to the background script. The background script feeds those into the existing `scheduleClose()`, so all the matching, interval, and cancel-on-navigate logic is unchanged.

Notes:

- No pattern changes. This only gives the existing patterns a chance to run in Safari.
- Content scripts run in an isolated world, so patching the page's `history.pushState` from the content script isn't reliable (it only patches the content script's own copy). Polling `location.href` works regardless.
- The match list mirrors the current `predefinedUrlPatterns` hosts, so the script does nothing on unrelated pages.

## Testing

Tested in Safari (unsigned/temporary extension):

- Linear: bare issue link now closes after the redirect to `?noRedirect=1`. This is the case I reproduced and verified end to end.
- Figma and Zoom: also close as expected.

I haven't verified every service individually. The ones I didn't test use the same code path, so I'd expect them to behave the same, but it'd be good to confirm. Some of them may already have worked if their redirect is a full load rather than an in-page one. In that case this just doesn't change anything for them, since `scheduleClose()` already de-dupes per tab.

## Possible follow-up

The content script polls every 500ms for the tab's lifetime. It only sends a message when the URL actually changes, so it's not chatty, but stopping the interval after a match or after some idle time would be a reasonable tightening if you'd prefer. Happy to add that if you want it in this PR.
