### PR TITLE
Match Notion app.notion.com native links

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ const predefinedUrlPatterns = [
   { label: 'Figjam Files', pattern: '^https?://(?:www\.)?figma\.com/board/' },
   { label: 'Linear', pattern: '^https?://linear\\.app/(?!integrations(/|$)|settings(/|$)).*\\?noRedirect=1$' },
   { label: 'Microsoft Teams', pattern: '^https?://teams\\.microsoft\\.com/dl/launcher/.*' },
-  { label: 'Notion', pattern: '^https?://www\\.notion\\.so/native/.*&deepLinkOpenNewTab=true' },
+  { label: 'Notion', pattern: '^https?://(app\\.notion\\.com|www\\.notion\\.so)/native/.*[?&]deepLinkOpenNewTab=true' },
   { label: 'Slack', pattern: '^https?://(?!(app\\.slack\\.com|slack\\.com|api\\.slack\\.com|.*\\/(admin|customize|account|apps|marketplace)(\\/|$)|.*\\/home(\\/|$)))[a-z0-9-]+\\.(enterprise\\.)?slack\\.com/' },
   { label: 'Spotify', pattern: '^https?://open\\.spotify\\.com' },
   { label: 'VS Code Live Share', pattern: '^https?://vscode\\.dev/liveshare' },


### PR DESCRIPTION
## What this fixes

Notion `/native/` deep links served from `app.notion.com` are never closed.

The predefined Notion pattern only matches `www.notion.so`, but Notion now serves its native deep-link redirect from `app.notion.com`. A real example of a link that should close but doesn't:

```
https://app.notion.com/native/p/<page>?source=copy_link&deepLinkOpenNewTab=true
```

The host is the only reason it fails. The path (`/native/`) and the `deepLinkOpenNewTab=true` param are both present, the pattern just doesn't accept the `app.notion.com` host.

## The change

```
- ^https?://www\.notion\.so/native/.*&deepLinkOpenNewTab=true
+ ^https?://(app\.notion\.com|www\.notion\.so)/native/.*[?&]deepLinkOpenNewTab=true
```

Two small things:

- Match both `app.notion.com` and `www.notion.so`, so existing `www.notion.so` links keep working.
- Use `[?&]` instead of a bare `&` before the param, so it also matches when `deepLinkOpenNewTab=true` is the first query param (`?deepLinkOpenNewTab=true`), not only when it follows another one.

This isn't Safari-specific. The host was wrong everywhere, so this helps all browsers.

## Testing

I verified the regex against the real `app.notion.com` URL above and a few `www.notion.so` variants (param first vs later), plus negative cases (plain Notion pages without the param don't match). I haven't yet confirmed the full close end to end in the browser, so it'd be good to sanity-check that a real Notion native link closes with this applied.
